### PR TITLE
fix(vscode): use ms-vscode.cpptools from nixpkgs to avoid link error

### DIFF
--- a/nixos/profiles/users/_sunHome.nix
+++ b/nixos/profiles/users/_sunHome.nix
@@ -48,7 +48,15 @@
     enableSshSupport = true;
     pinentryPackage = pkgs.pinentry-gnome3;
   };
+
+  programs.neovim.enable = true;
+  programs.neovim.viAlias = true;
+
   programs.vscode.enable = true;
+  # FIXME: ms-vscode.cpptools contains dynamically linked OpenDebugAD7.
+  programs.vscode.extensions = with pkgs.vscode-extensions; [
+    ms-vscode.cpptools
+  ];
 
   xdg = {
     enable = true;


### PR DESCRIPTION
`OpenDebugAD7 ` in `ms-vscode.cpptools` is a dynamically linked executable. It will fail to execute on NixOS. We've considered the following possible solutions.
1. **use `vscode-with-extensions` package provided by nixpkgs**: VSCode extensions panel will become read-only.
2. **use `vscode-fhs` package provided by nixpkgs**: VSCode will be launched in a sandbox, and setuid executables, e.g., `sudo` will become unusable.
3. **use `programs.vscode.packages` option provide by home-manger**: VSCode may update and override the extensions if `mutableExtensionsDir = true` (by default)

We decided to choose solution 3 and turn off VSCode extensions auto update.